### PR TITLE
feat: Separate 1P and 2P modes by gameState Constructor

### DIFF
--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -116,7 +116,11 @@ public final class Core {
 
 		int returnCode = 1;
 		do {
-			gameState = new GameState(1, 0, MAX_LIVES, MAX_LIVES, 0, 0);
+			// TODO 1P mode와 2p mode 진입 구현
+			gameState = new GameState(1, 0, MAX_LIVES, 0, 0);
+
+			// 2p mode의 gameState 생성자
+			// gameState = new GameState(1, 0, MAX_LIVES, MAX_LIVES, 0, 0);
 
 			switch (returnCode) {
 			case 1:
@@ -131,11 +135,19 @@ public final class Core {
 				// Game & score.
 				do {
 					// One extra live every few levels.
-					boolean bonusLife = gameState.getLevel()
-							% EXTRA_LIFE_FRECUENCY == 0
-							&& gameState.getLivesRemaining1p() < MAX_LIVES
-							&& gameState.getLivesRemaining2p() < MAX_LIVES;
-					
+					int mode = gameState.getMode();
+					boolean bonusLife = gameState.getLevel() % EXTRA_LIFE_FRECUENCY == 0;
+
+					if (mode == 1) {
+						// 1P mode
+						bonusLife = bonusLife && gameState.getLivesRemaining1p() < MAX_LIVES;
+					} else {
+						// 2P 모드 (두 플레이어 중 하나라도 생명이 적을 경우 bonusLife 부여)
+						bonusLife = bonusLife &&
+								(gameState.getLivesRemaining1p() < MAX_LIVES
+										|| gameState.getLivesRemaining2p() < MAX_LIVES);
+					}
+
 					currentScreen = new GameScreen(gameState,
 							gameSettings.get(gameState.getLevel() - 1),
 							bonusLife, width, height, FPS);
@@ -144,26 +156,43 @@ public final class Core {
 					frame.setScreen(currentScreen);
 					LOGGER.info("Closing game screen.");
 
-					gameState = ((GameScreen) currentScreen).getGameState2p();
-
-					gameState = new GameState(gameState.getLevel() + 1,
-							gameState.getScore(),
-							gameState.getLivesRemaining1p(),
-							gameState.getLivesRemaining2p(),
-							gameState.getBulletsShot(),
-							gameState.getShipsDestroyed());
-
-				} while (gameState.getLivesRemaining1p() > 0
-						&& gameState.getLivesRemaining2p() > 0
+					if (mode == 1) {
+						gameState = ((GameScreen) currentScreen).getGameState1p();
+						gameState = new GameState(gameState.getLevel() + 1,
+								gameState.getScore(),
+								gameState.getLivesRemaining1p(),
+								gameState.getBulletsShot(),
+								gameState.getShipsDestroyed());
+					} else {
+						gameState = ((GameScreen) currentScreen).getGameState2p();
+						gameState = new GameState(gameState.getLevel() + 1,
+								gameState.getScore(),
+								gameState.getLivesRemaining1p(),
+								gameState.getLivesRemaining2p(),
+								gameState.getBulletsShot(),
+								gameState.getShipsDestroyed());
+					}
+				} while ((gameState.getMode() == 1 && gameState.getLivesRemaining1p() > 0)
+						|| (gameState.getMode() == 2 && gameState.getLivesRemaining1p() > 0 && gameState.getLivesRemaining2p() > 0)
 						&& gameState.getLevel() <= NUM_LEVELS);
 
-				LOGGER.info("Starting " + WIDTH + "x" + HEIGHT
+				if (gameState.getMode() == 1) {
+					LOGGER.info("Starting " + WIDTH + "x" + HEIGHT
 						+ " score screen at " + FPS + " fps, with a score of "
 						+ gameState.getScore() + ", "
 						+ gameState.getLivesRemaining1p() + " lives remaining for 1p, "
-						+ gameState.getLivesRemaining2p() + " lives remaining for 2p, "
 						+ gameState.getBulletsShot() + " bullets shot and "
 						+ gameState.getShipsDestroyed() + " ships destroyed.");
+				} else {
+					LOGGER.info("Starting " + WIDTH + "x" + HEIGHT
+							+ " score screen at " + FPS + " fps, with a score of "
+							+ gameState.getScore() + ", "
+							+ gameState.getLivesRemaining1p() + " lives remaining for 1p, "
+							+ gameState.getLivesRemaining2p() + " lives remaining for 2p, "
+							+ gameState.getBulletsShot() + " bullets shot and "
+							+ gameState.getShipsDestroyed() + " ships destroyed.");
+				}
+
 				currentScreen = new ScoreScreen(width, height, FPS, gameState);
 				returnCode = frame.setScreen(currentScreen);
 				LOGGER.info("Closing score screen.");

--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -116,11 +116,10 @@ public final class Core {
 
 		int returnCode = 1;
 		do {
-			// TODO 1P mode와 2p mode 진입 구현
-			gameState = new GameState(1, 0, MAX_LIVES, 0, 0);
-
-			// 2p mode의 gameState 생성자
-			// gameState = new GameState(1, 0, MAX_LIVES, MAX_LIVES, 0, 0);
+			// TODO 1P mode와 2P mode 진입 구현
+			// TODO gameState 생성자에 따라 1P와 2P mode 구분
+			// gameState = new GameState(1, 0, MAX_LIVES, 0, 0);
+			gameState = new GameState(1, 0, MAX_LIVES, MAX_LIVES, 0, 0);
 
 			switch (returnCode) {
 			case 1:

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -342,7 +342,48 @@ public final class DrawManager {
 	}
 
 	/**
-	 * Draws game results.
+	 * Draws game results for 1P mode.
+	 *
+	 * @param screen
+	 *            Screen to draw on.
+	 * @param score
+	 *            Score obtained.
+	 * @param livesRemaining1
+	 *            1p's lives remaining when finished.
+	 * @param shipsDestroyed
+	 *            Total ships destroyed.
+	 * @param accuracy
+	 *            Total accuracy.
+	 *
+	 * @param isNewRecord
+	 *            If the score is a new high score.
+	 */
+	public void drawResults(final Screen screen, final int score,
+							final int livesRemaining1, final int shipsDestroyed,
+							final float accuracy, final boolean isNewRecord) {
+		String scoreString = String.format("score %04d", score);
+		String lives1RemainingString = "lives remaining " + livesRemaining1;
+		String shipsDestroyedString = "enemies destroyed " + shipsDestroyed;
+		String accuracyString = String
+				.format("accuracy %.2f%%", accuracy * 100);
+
+		int height = isNewRecord ? 4 : 2;
+
+		backBufferGraphics.setColor(Color.WHITE);
+		drawCenteredRegularString(screen, scoreString, screen.getHeight()
+				/ height);
+		drawCenteredRegularString(screen, lives1RemainingString,
+				screen.getHeight() / height + fontRegularMetrics.getHeight()
+						* 2);
+		drawCenteredRegularString(screen, shipsDestroyedString,
+				screen.getHeight() / height + fontRegularMetrics.getHeight()
+						* 4);
+		drawCenteredRegularString(screen, accuracyString, screen.getHeight()
+				/ height + fontRegularMetrics.getHeight() * 6);
+	}
+
+	/**
+	 * Draws game results for 2P mode.
 	 *
 	 * @param screen
 	 *            Screen to draw on.

--- a/src/engine/GameState.java
+++ b/src/engine/GameState.java
@@ -20,7 +20,7 @@ public class GameState {
 	private int bulletsShot;
 	/** Ships destroyed until now. */
 	private int shipsDestroyed;
-
+	/** Distinguish 1P and 2P mode. */
 	private int gameMode = 0;
 	/**
 	 * Constructor.
@@ -36,6 +36,8 @@ public class GameState {
 	 * @param shipsDestroyed
 	 *            Ships destroyed until now.
 	 */
+
+	// 1p mode
 	public GameState(final int level, final int score,
 					final int livesRemaining, final int bulletsShot,
 					final int shipsDestroyed) {
@@ -47,6 +49,7 @@ public class GameState {
 		this.shipsDestroyed = shipsDestroyed;
 	}
 
+	// 2p mode
 	public GameState(final int level, final int score,
 					 final int livesRemaining1, final int livesRemaining2, final int bulletsShot,
 					 final int shipsDestroyed) {

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -105,11 +105,14 @@ public class GameScreen extends Screen {
 		this.level = gameState.getLevel();
 		this.score = gameState.getScore();
 		this.lives = gameState.getLivesRemaining1p();
-		this.lives2 = gameState.getLivesRemaining2p();
+
+		if (gameState.getMode() == 2) {
+			this.lives2 = gameState.getLivesRemaining2p();
+		}
 
 		if (this.bonusLife) {
 			this.lives++;
-			this.lives2++;
+			if (gameState.getMode() == 2) this.lives2++;
 		}
 
 		this.bulletsShot = gameState.getBulletsShot();
@@ -127,8 +130,7 @@ public class GameScreen extends Screen {
 
 
 		this.ship = new Ship(this.width / 2 + 50, this.height - 30, Color.GREEN);
-		/* 2player 함선 객체 생성 */
-		this.ship2 = new Ship(this.width / 2 - 30, this.height - 30, Color.RED);
+		// this.ship2 = new Ship(this.width / 2 - 30, this.height - 30, Color.RED);
 
 		// Appears each 10-30 seconds.
 		this.enemyShipSpecialCooldown = Core.getVariableCooldown(
@@ -188,7 +190,7 @@ public class GameScreen extends Screen {
 						this.bulletsShot++;
 			}
 
-			if (!this.ship2.isDestroyed() /* && 2player 전환 bool값 */) {
+			/*if (!this.ship2.isDestroyed() *//* && 2player 전환 bool값 *//*) {
 				boolean moveRight = inputManager.isKeyDown(KeyEvent.VK_D);
 				boolean moveLeft = inputManager.isKeyDown(KeyEvent.VK_A);
 
@@ -206,7 +208,7 @@ public class GameScreen extends Screen {
 				if (inputManager.isKeyDown(KeyEvent.VK_W))
 					if (this.ship2.shoot(this.bullets))
 						this.bulletsShot++;
-			}
+			}*/
 
 			if (this.enemyShipSpecial != null) {
 				if (!this.enemyShipSpecial.isDestroyed())
@@ -260,8 +262,8 @@ public class GameScreen extends Screen {
 				this.ship.getPositionY());
 		/* if(2player 전환 bool값) */
 		/* 화면에 2player 함선 생성 */
-		drawManager.drawEntity(this.ship2, this.ship2.getPositionX(),
-        		this.ship2.getPositionY());
+		/*drawManager.drawEntity(this.ship2, this.ship2.getPositionX(),
+        		this.ship2.getPositionY());*/
 
 		if (this.enemyShipSpecial != null)
 			drawManager.drawEntity(this.enemyShipSpecial,

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -39,6 +39,8 @@ public class GameScreen extends Screen {
 	/** Height of the interface separation line. */
 	private static final int SEPARATION_LINE_HEIGHT = 40;
 
+	/** Current game state. */
+	private GameState gameState;
 	/** Current game difficulty settings. */
 	private GameSettings gameSettings;
 	/** Current difficulty level number. */
@@ -100,6 +102,7 @@ public class GameScreen extends Screen {
 					  final int width, final int height, final int fps) {
 		super(width, height, fps);
 
+		this.gameState = gameState;
 		this.gameSettings = gameSettings;
 		this.bonusLife = bonusLife;
 		this.level = gameState.getLevel();
@@ -128,9 +131,10 @@ public class GameScreen extends Screen {
 		enemyShipFormation = new EnemyShipFormation(this.gameSettings);
 		enemyShipFormation.attach(this);
 
-
 		this.ship = new Ship(this.width / 2 + 50, this.height - 30, Color.GREEN);
-		// this.ship2 = new Ship(this.width / 2 - 30, this.height - 30, Color.RED);
+		if (gameState.getMode() == 2) {
+			this.ship2 = new Ship(this.width / 2 - 30, this.height - 30, Color.RED);
+		}
 
 		// Appears each 10-30 seconds.
 		this.enemyShipSpecialCooldown = Core.getVariableCooldown(
@@ -190,7 +194,7 @@ public class GameScreen extends Screen {
 						this.bulletsShot++;
 			}
 
-			/*if (!this.ship2.isDestroyed() *//* && 2player 전환 bool값 *//*) {
+			if (gameState.getMode() == 2 && !this.ship2.isDestroyed()) {
 				boolean moveRight = inputManager.isKeyDown(KeyEvent.VK_D);
 				boolean moveLeft = inputManager.isKeyDown(KeyEvent.VK_A);
 
@@ -208,7 +212,7 @@ public class GameScreen extends Screen {
 				if (inputManager.isKeyDown(KeyEvent.VK_W))
 					if (this.ship2.shoot(this.bullets))
 						this.bulletsShot++;
-			}*/
+			}
 
 			if (this.enemyShipSpecial != null) {
 				if (!this.enemyShipSpecial.isDestroyed())
@@ -229,9 +233,10 @@ public class GameScreen extends Screen {
 			}
 
 			this.ship.update();
-			/* 2player 함선 상태 체크 */
-			/* if(2player 전환 bool값) */
-			this.ship2.update();
+			if (this.gameState.getMode() == 2) {
+				this.ship2.update();
+			}
+
 			this.enemyShipFormation.update();
 			this.enemyShipFormation.shoot(this.bullets);
 		}
@@ -240,8 +245,7 @@ public class GameScreen extends Screen {
 		cleanBullets();
 		draw();
 
-		if ((this.enemyShipFormation.isEmpty() || this.lives == 0 || this.lives2 == 0)
-				// 1player 또는 2player의 lives = 0 --> 게임 종료
+		if ((this.enemyShipFormation.isEmpty() || this.lives == 0 || (this.gameState.getMode() == 2 && this.lives2 == 0))
 				&& !this.levelFinished) {
 			this.levelFinished = true;
 			this.screenFinishedCooldown.reset();
@@ -258,12 +262,15 @@ public class GameScreen extends Screen {
 	private void draw() {
 		drawManager.initDrawing(this);
 
-		drawManager.drawEntity(this.ship, this.ship.getPositionX(),
-				this.ship.getPositionY());
-		/* if(2player 전환 bool값) */
-		/* 화면에 2player 함선 생성 */
-		/*drawManager.drawEntity(this.ship2, this.ship2.getPositionX(),
-        		this.ship2.getPositionY());*/
+		if (this.gameState.getMode() == 1) {
+			drawManager.drawEntity(this.ship, this.ship.getPositionX(),
+					this.ship.getPositionY());
+		} else {
+			drawManager.drawEntity(this.ship, this.ship.getPositionX(),
+					this.ship.getPositionY());
+			drawManager.drawEntity(this.ship2, this.ship2.getPositionX(),
+					this.ship2.getPositionY());
+		}
 
 		if (this.enemyShipSpecial != null)
 			drawManager.drawEntity(this.enemyShipSpecial,
@@ -278,7 +285,7 @@ public class GameScreen extends Screen {
 
 		drawManager.drawScore(this, this.score);
 		drawManager.drawLives(this, this.lives);
-		drawManager.drawLives2(this, this.lives2);
+		if (this.gameState.getMode() == 2) drawManager.drawLives2(this, this.lives2);
 
 		drawManager.drawHorizontalLine(this, SEPARATION_LINE_HEIGHT - 1);
 
@@ -331,9 +338,7 @@ public class GameScreen extends Screen {
 					}
 				}
 
-				/* 2player 함선 총알 피격 처리
-				2player 생명 따로 처리 필요 */
-				if (/*2player 전환 bool 값 && */ checkCollision(bullet, this.ship2) && !this.levelFinished) {
+				if (this.gameState.getMode() == 2 && checkCollision(bullet, this.ship2) && !this.levelFinished) {
 					recyclable.add(bullet);
 					if (!this.ship2.isDestroyed()) {
 						this.ship2.destroy();

--- a/src/screen/ScoreScreen.java
+++ b/src/screen/ScoreScreen.java
@@ -69,7 +69,11 @@ public class ScoreScreen extends Screen {
 		this.gameMode = gameState.getMode();
 		this.score = gameState.getScore();
 		this.livesRemaining1 = gameState.getLivesRemaining1p();
-		this.livesRemaining2 = gameState.getLivesRemaining2p();
+
+		if (gameState.getMode() == 2) {
+			this.livesRemaining2 = gameState.getLivesRemaining2p();
+		}
+
 		this.bulletsShot = gameState.getBulletsShot();
 		this.shipsDestroyed = gameState.getShipsDestroyed();
 		this.isNewRecord = false;
@@ -107,7 +111,12 @@ public class ScoreScreen extends Screen {
 	protected final void update() {
 		super.update();
 
-		draw();
+		if (gameMode == 1) {
+			draw();
+		} else {
+			draw2();
+		}
+
 		if (this.inputDelay.checkFinished()) {
 			if (inputManager.isKeyDown(KeyEvent.VK_ESCAPE)) {
 				// Return to main menu.
@@ -173,6 +182,24 @@ public class ScoreScreen extends Screen {
 	 * Draws the elements associated with the screen.
 	 */
 	private void draw() {
+		drawManager.initDrawing(this);
+
+		drawManager.drawGameOver(this, this.inputDelay.checkFinished(),
+				this.isNewRecord);
+		drawManager.drawResults(this, this.score, this.livesRemaining1,
+				this.shipsDestroyed, (float) this.shipsDestroyed
+						/ this.bulletsShot, this.isNewRecord);
+
+		if (this.isNewRecord)
+			drawManager.drawNameInput(this, this.name, this.nameCharSelected);
+
+		drawManager.completeDrawing(this);
+	}
+
+	/**
+	 * Draws the elements associated with the screen for 2P mode.
+	 */
+	private void draw2() {
 		drawManager.initDrawing(this);
 
 		drawManager.drawGameOver(this, this.inputDelay.checkFinished(),


### PR DESCRIPTION
gameState 생성자를 통해 1P mode와 2P mode를 구분할 수 있도록 수정했습니다.
Core.class에서 어떤 gameState 객체를 선정하는지에 따라 두 개의 mode가 구분됩니다.

- 1P mode용: `gameState = new GameState(1, 0, MAX_LIVES, 0, 0);`

- 2P mode용: `gameState = new GameState(1, 0, MAX_LIVES, MAX_LIVES, 0, 0);`

main TEAM과 협업할 때, 두 개의 생성자 중 적절한 것을 이용해 객체 생성하도록 협업하면 될 것 같습니다.
해당 생성자를 통해 gameState 객체만 정상적으로 생성되면, 이외 코드 수정사항 없겠습니다.